### PR TITLE
Adds support for different species of String in NeoJSONReader streams

### DIFF
--- a/repository/Neo-JSON-Core/NeoJSONReader.class.st
+++ b/repository/Neo-JSON-Core/NeoJSONReader.class.st
@@ -39,7 +39,7 @@ Class {
 		'mapClass',
 		'propertyNamesAsSymbols'
 	],
-	#category : 'Neo-JSON-Core'
+	#category : #'Neo-JSON-Core'
 }
 
 { #category : #convenience }
@@ -451,13 +451,22 @@ NeoJSONReader >> propertyNamesAsSymbols: boolean [
 ]
 
 { #category : #private }
+NeoJSONReader >> stringStreamClass [
+	"Answer the class of the collection used for the stringStream of receiver.
+	
+	NOTE: It is String, but if receiver's readStream is over 
+	another class of String, then this provides compatibility for that."
+
+	^ readStream collectionSpecies
+]
+
+{ #category : #private }
 NeoJSONReader >> stringStreamContents: block [
 	"Like String streamContents: block
 	but reusing the underlying buffer for improved efficiency"
-	
-	stringStream 
-		ifNil: [ 
-			stringStream := (String new: 32) writeStream ].
+
+	stringStream ifNil: [ 
+		stringStream := (self stringStreamClass new: 32) writeStream ].
 	stringStream reset.
 	block value: stringStream.
 	^ stringStream contents


### PR DESCRIPTION
Since VAST 11, and in order to be able to use the new `UnicodeString` as a drop-in replacement of `String`, we need to remove hard coded references to `String` and instead pass it as an argument or deduce the class from some other object.

This pull request changes the hard-coded reference to `String` in the creation of `NeoJSONReader`'s `stringStream`, and delegates the class used to its existing `readStream` from which it was instantiated.