### PR TITLE
Prevent adding #errorKeyNotFound key in case of missing key1 or key2.

### DIFF
--- a/repository/Neo-JSON-Core/NeoJSONObject.class.st
+++ b/repository/Neo-JSON-Core/NeoJSONObject.class.st
@@ -64,6 +64,15 @@ NeoJSONObject >> at: key [
 ]
 
 { #category : #accessing }
+NeoJSONObject >> at: key1 at: key2 [
+
+	"Answer nil for missing keys.
+	My superclass would signal a KeyNotFound."
+	
+	^ self at: key1 at: key2 ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
 NeoJSONObject >> at: key ifPresent: aPresentBlock ifAbsentPut: anAbsentBlock [
 	"Lookup the given key in the receiver. If it is present, answer the
 	value of evaluating the first block optionally with the value associated with the key.


### PR DESCRIPTION
With the current stable Pharo versions, sending #at:at: to a NeoJSONObject instance results in an entry being created with key 'errorKeyNotFound' and the missing key as value. This is because of a bug in OrderedDictionary, which sends #errorKeyNotFound: when a key is missing, but which is not implemented (since it subclasses Collection, not Dictionary).

Pharo issue https://github.com/pharo-project/pharo/issues/13587 should resolve the bug in OrderedDictionary, but will take time to be rolled out.

Also, the expected behavior of NeoJSONObject is to return nil when a key is not found, which makes this change useful regardless.

Fixes #18.