### PR TITLE
Nix flake proposal

### DIFF
--- a/.nix/flake.lock
+++ b/.nix/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "v1.0.0",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "v1.0.0",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744664988,
+        "narHash": "sha256-tv5QkwoHUT7957XYPOWpyBD440SdfPBPBVymbXlmqsc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eff64d6c1a13c9a3348f332f75cbde1935dc3d21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pharo-vm-12": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "pharo-vm",
+        "lastModified": 1744567847,
+        "narHash": "sha256-Am5h1E69nFUdjD+XDFRw7wB3Lr2k2bxrRKygy96LJCA=",
+        "owner": "rydnr",
+        "repo": "nix-flakes",
+        "rev": "6369c686e0d7d974e0de93685bd4b16615bb5113",
+        "type": "github"
+      },
+      "original": {
+        "dir": "pharo-vm",
+        "owner": "rydnr",
+        "ref": "pharo-vm-12.0.1519.2",
+        "repo": "nix-flakes",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pharo-vm-12": "pharo-vm-12"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -1,0 +1,122 @@
+{
+  description = "Flake for svenvc/neojson";
+
+  inputs = rec {
+    flake-utils.url = "github:numtide/flake-utils/v1.0.0";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    pharo-vm-12 = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:rydnr/nix-flakes/pharo-vm-12.0.1519.2?dir=pharo-vm";
+    };
+  };
+  outputs = inputs:
+    with inputs;
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        org = "svenvc";
+        repo = "neojson";
+        pname = "${repo}";
+        tag = "v18";
+        baseline = "NeoJSON";
+        pkgs = import nixpkgs { inherit system; };
+        description = "An elegant and efficient Smalltalk framework to read and write JSON converting to or from Smalltalk objects";
+        license = pkgs.lib.licenses.mit;
+        homepage = "https://github.com/svenvc/neojson";
+        maintainers = with pkgs.lib.maintainers; [ ];
+        nixpkgsVersion = builtins.readFile "${nixpkgs}/.version";
+        nixpkgsRelease =
+          builtins.replaceStrings [ "\n" ] [ "" ] "nixpkgs-${nixpkgsVersion}";
+        shared = import ./shared.nix;
+        svenvc-neojson-for = { bootstrap-image-name, bootstrap-image-sha256, bootstrap-image-url, pharo-vm }:
+          let
+            bootstrap-image = pkgs.fetchurl {
+              url = bootstrap-image-url;
+              sha256 = bootstrap-image-sha256;
+            };
+            src = ./../repository;
+          in pkgs.stdenv.mkDerivation (finalAttrs: {
+            version = tag;
+            inherit pname src;
+
+            strictDeps = true;
+
+            buildInputs = with pkgs; [
+            ];
+
+            nativeBuildInputs = with pkgs; [
+              pharo-vm
+              pkgs.unzip
+            ];
+
+            unpackPhase = ''
+              unzip -o ${bootstrap-image} -d image
+              # cp -r ${src} src
+            '';
+
+            configurePhase = ''
+              runHook preConfigure
+
+              # load baseline
+              ${pharo-vm}/bin/pharo image/${bootstrap-image-name} eval --save "EpMonitor current disable. NonInteractiveTranscript stdout install. [ Metacello new repository: 'filetree://${src}'; baseline: '${baseline}'; onConflictUseLoaded; load ] ensure: [ EpMonitor current enable ]"
+
+              runHook postConfigure
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+
+              # assemble
+              ${pharo-vm}/bin/pharo image/${bootstrap-image-name} save "${pname}"
+
+              mkdir dist
+              mv image/${pname}.* dist/
+
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out
+              cp -r ${pharo-vm}/bin $out
+              cp -r ${pharo-vm}/lib $out
+              cp -r dist/* $out/
+              cp image/*.sources $out/
+              mkdir $out/share
+              pushd ${src}
+              ${pkgs.zip}/bin/zip -r $out/share/src.zip .
+              popd
+
+              runHook postInstall
+             '';
+
+            meta = {
+              longDescription = ''
+                    NeoJSON is an elegant and efficient standalone Smalltalk framework to read and write JSON converting to or from Smalltalk objects.
+              '';
+              inherit description homepage license maintainers;
+              mainProgram = "pharo";
+              platforms = pkgs.lib.platforms.linux;
+            };
+        });
+      in rec {
+        defaultPackage = packages.default;
+        devShells = rec {
+          default = svenvc-neojson-12;
+          svenvc-neojson-12 = shared.devShell-for {
+            package = packages.svenvc-neojson-12;
+            inherit org pkgs repo tag;
+            nixpkgs-release = nixpkgsRelease;
+          };
+        };
+        packages = rec {
+          default = svenvc-neojson-12;
+          svenvc-neojson-12 = svenvc-neojson-for rec {
+            bootstrap-image-url = pharo-vm-12.resources.${system}.bootstrap-image-url;
+            bootstrap-image-sha256 = pharo-vm-12.resources.${system}.bootstrap-image-sha256;
+            bootstrap-image-name = pharo-vm-12.resources.${system}.bootstrap-image-name;
+            pharo-vm = pharo-vm-12.packages.${system}.pharo-vm;
+          };
+        };
+      });
+}

--- a/.nix/shared.nix
+++ b/.nix/shared.nix
@@ -1,0 +1,35 @@
+# .nix/shared.nix
+#
+# This file provides functions used by NeoJSON's Nix flake.
+#
+# MIT License
+#
+# Copyright (C) 2012 Sven Van Caekenberghe
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+rec {
+  shellHook-for = { nixpkgs-release, org, package, repo, tag }:
+    ''
+      export PS1="\033[37m[\[\033[01;34m\]${org}/${repo}\033[01;37m|\033[01;33m${tag}[\033[00m\] "
+      echo -e "\033[36m▗▖  ▗▖▗▞▀▚▖ ▄▄▄ \033[31m ▗▖ ▗▄▄▖ ▗▄▖ ▗▖  ▗▖  \033[32mhttps://github.com/${org}\033[0m"
+      echo -e "\033[36m▐▛▚▖▐▌▐▛▀▀▘█   █\033[31m ▐▌▐▌   ▐▌ ▐▌▐▛▚▖▐▌  \033[33mhttps://github.com/${org}/${repo}:${tag}\033[0m"
+      echo -e "\033[36m▐▌ ▝▜▌▝▚▄▄▖▀▄▄▄▀\033[31m ▐▌ ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌  \033[34mhttps://pharo.org\033[0m"
+      echo -e "\033[36m▐▌  ▐▌ \033[0m       \033[31m▗▄▄▞▘▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌  \033[35mhttps://github.com/nixos/nixpkgs/tree/${nixpkgs-release}\033[0m"
+      echo
+      echo -e "Thank you for using \033[32m${package.pname}\033[0m \033[33m${package.version}\033[0m \033[31m(${org}/${repo}-${tag})\033[0m and for your appreciation of Smalltalk."
+    '';
+  devShell-for = { nixpkgs-release, org, package, pkgs, repo, tag}:
+    pkgs.mkShell {
+      shellHook = shellHook-for {
+          inherit nixpkgs-release org package repo tag;
+      };
+    };
+  app-for = { package, entrypoint }: {
+    type = "app";
+    program = "${package}/bin/${entrypoint}.sh";
+  };
+}


### PR DESCRIPTION
It uses an unofficial Nix [1] flake [2] for the PharoVM, that is in alpha stage.

Usage:
- To launch a shell with Pharo 12 available: `cd .nix && nix develop .`
- To build the NeoJSON derivation (a blank Pharo 12 image with NeoJSON loaded):
`cd .nix && nix build .`
- To list the available outputs of the flake: `cd .nix && nix flake show .`
- To inspect the flake metadata: `cd .nix && nix flake metadata .`

[1] https://nixos.org
[2] https://github.com/rydnr/nix-flakes/tree/main/pharo-vm